### PR TITLE
Add option to modify startup behaviour

### DIFF
--- a/in_memory_store.go
+++ b/in_memory_store.go
@@ -25,7 +25,7 @@ func NewInMemoryStore() *InMemoryStore {
 }
 
 // Start the store.
-func (st *InMemoryStore) Start() error {
+func (st *InMemoryStore) Start(_ StartupBehaviour) error {
 	return nil
 }
 

--- a/mongodb/store.go
+++ b/mongodb/store.go
@@ -120,13 +120,18 @@ func (s *Store) wrapError(err error) error {
 // Start is called when the manager starts up.
 // We ensure that stale jobs are marked as failed so that we have place
 // for new jobs.
-func (s *Store) Start() error {
-	// TODO This will fail if we have two or more job queues working on the same database!
-	change := bson.M{"$set": bson.M{"state": jobqueue.Failed, "completed": time.Now().UnixNano()}}
-	_, err := s.coll.UpdateAll(
-		bson.M{"state": jobqueue.Working},
-		change,
-	)
+func (s *Store) Start(b jobqueue.StartupBehaviour) error {
+	var err error
+
+	if b == jobqueue.MarkAsFailed {
+		// This will fail if we have two or more job queues working on the same database!
+		change := bson.M{"$set": bson.M{"state": jobqueue.Failed, "completed": time.Now().UnixNano()}}
+		_, err = s.coll.UpdateAll(
+			bson.M{"state": jobqueue.Working},
+			change,
+		)
+	}
+
 	return s.wrapError(err)
 }
 

--- a/store.go
+++ b/store.go
@@ -20,7 +20,7 @@ type Store interface {
 	// Start is called when the manager starts up.
 	// This is a good time for cleanup. E.g. a persistent store might moved
 	// crashed jobs from a previous run into the Failed state.
-	Start() error
+	Start(StartupBehaviour) error
 
 	// Create adds a job to the store.
 	Create(context.Context, *Job) error


### PR DESCRIPTION
The new `StartupBehaviour` option allows to define what happens when a
new `Manager` is started. It is passed on to the `Start(...)` method
defined in the `Store` interface.

Valid options as of now are:

* `None` which doesn't touch the existing jobqueue at all
* `MarkAsFailed` which asks the `Store` implementation to set all
  jobs currently marked as "running" to "failed". This is not a
  feasible solution if your managers run on multiple nodes.

Close #3